### PR TITLE
A whole buncha changes. Mainly the menu.

### DIFF
--- a/_data/twenty_23/locations.yml
+++ b/_data/twenty_23/locations.yml
@@ -1,7 +1,7 @@
-- title: "Accomodation"
-  name: accomodation
+- title: "Accommodation"
+  name: accommodation
   subtitle: <a href = "https://jugendherberge.de/jugendherbergen/duesseldorf-442/portraet/">DJH Jugendherberge Düsseldorf</a>
-  img: accommodation.jpg
+  img: accomodation.jpg
   thumbnail: accomodation.jpg
   alt: Where you will be sleeping 
   description: Foto Ⓒ Jugendherberge Düsseldorf<br>Düsseldorfer Str. 1,<br>40545 Düsseldorf<br>From here, you can reach the venue <a href ="https://www.google.com/maps/dir/University+Dusseldorf:+Humanities,+Universit%C3%A4tsstra%C3%9Fe+1,+40225+D%C3%BCsseldorf,+Germany/DJH+Jugendherberge+D%C3%BCsseldorf,+D%C3%BCsseldorfer+Str.+1,+40545+D%C3%BCsseldorf/@51.2073217,6.7410264,13z/data=!3m2!4b1!5s0x47b8ca05e12f93d7:0x3dd099896c7809d7!4m18!4m17!1m5!1m1!1s0x47b8cb002ac3e3c3:0xe100c7ca17c2a04e!2m2!1d6.7946577!2d51.1893431!1m5!1m1!1s0x47b8ca05e1ed2abb:0x3d17d218c2ba6960!2m2!1d6.7577514!2d51.2268091!2m3!6e0!7e2!8j1674637200!3e3">by bus in only 20 minutes</a>. In the unlikely case that you would like to skip some talks during the conference, you may take a stroll at the Rhine or just go to town and enjoy Düsseldorf, which is right on the other side of the river.

--- a/_data/twenty_23/locations.yml
+++ b/_data/twenty_23/locations.yml
@@ -1,7 +1,7 @@
 - title: "Accomodation"
   name: accomodation
   subtitle: <a href = "https://jugendherberge.de/jugendherbergen/duesseldorf-442/portraet/">DJH Jugendherberge Düsseldorf</a>
-  img: accomodation.jpg
+  img: accommodation.jpg
   thumbnail: accomodation.jpg
   alt: Where you will be sleeping 
   description: Foto Ⓒ Jugendherberge Düsseldorf<br>Düsseldorfer Str. 1,<br>40545 Düsseldorf<br>From here, you can reach the venue <a href ="https://www.google.com/maps/dir/University+Dusseldorf:+Humanities,+Universit%C3%A4tsstra%C3%9Fe+1,+40225+D%C3%BCsseldorf,+Germany/DJH+Jugendherberge+D%C3%BCsseldorf,+D%C3%BCsseldorfer+Str.+1,+40545+D%C3%BCsseldorf/@51.2073217,6.7410264,13z/data=!3m2!4b1!5s0x47b8ca05e12f93d7:0x3dd099896c7809d7!4m18!4m17!1m5!1m1!1s0x47b8cb002ac3e3c3:0xe100c7ca17c2a04e!2m2!1d6.7946577!2d51.1893431!1m5!1m1!1s0x47b8ca05e1ed2abb:0x3d17d218c2ba6960!2m2!1d6.7577514!2d51.2268091!2m3!6e0!7e2!8j1674637200!3e3">by bus in only 20 minutes</a>. In the unlikely case that you would like to skip some talks during the conference, you may take a stroll at the Rhine or just go to town and enjoy Düsseldorf, which is right on the other side of the river.

--- a/_includes/2023_data/about.html
+++ b/_includes/2023_data/about.html
@@ -3,7 +3,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">About</h2>
+                    <h2 class="section-heading">More Information</h2>
                     <!-- <h3 class="section-subheading text-muted"></h3> -->
                 </div>
             </div>

--- a/_includes/2023_data/dates.html
+++ b/_includes/2023_data/dates.html
@@ -1,0 +1,33 @@
+<!-- Services Section -->
+    <section id="dates">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+			<h2 class="section-heading">Important Dates</h2>
+				<h3 class="section-heading">Call for Papers</h3>
+					<!-- <b>Opens March 10th</b> and <b>closes April 10th</b> -->
+					- Opens March 10th
+					<br>
+					- Closes April 10th
+					<br>
+					Notice of acceptance will be sent by <b>May 22th</b>.
+					<br> 
+				<h3 class="section-heading">Registration</h3>
+				- Opens very soon
+				<br> 
+				- Closes June 1st. 
+				<br>
+				<hr style="height:30pt; visibility:hidden;" />
+				<h2 class="section-heading">What is the TaCoS?</h2>
+					<center>
+					<p> The Tagung der Computerlinguistik-Studierenden (TaCoS) was first organized in 1992 and takes place once every year. It offers students of computational linguistics and adjacent fields a chance to exchange views during talks and workshops. The conference is hosted by teams of student volunteers at their university. Participants traditionally receive accommodation and breakfast in exchange for a small fee. At the center of the conference stand talks, workshops, and poster sessions; each given by students for students. Established academics from the host university are invited as keynote speakers as well. In addition, there is a social program for everyone to connect and network.
+					<br>
+					This year marks the 32. TaCoS and our team at Heinrich-Heine University in Düsseldorf is proud to host the event this summer.
+					</p>
+				<center><a href="https://docs.google.com/forms/d/e/1FAIpQLSfuQaKA4w67P2gnkGZPbSFiQEJyqMo2YlbWww-Wh5rXL-8Xdg/viewform" class="page-scroll btn btn-xl">Sign up for the newsletter</a></center>
+                <p><a href="https://linguistik.computer/">Previous TaCoS conferences</a> 
+                </p> 
+				</div>
+            </div>
+		</div>
+    </section>

--- a/_includes/2023_data/header-home.html
+++ b/_includes/2023_data/header-home.html
@@ -26,6 +26,10 @@ function growShrinkLogo() {
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
+					<span class="icon-bar"></span>
                 </button>
                 
             </div>
@@ -34,15 +38,30 @@ function growShrinkLogo() {
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="hidden">
-                        <a href="/"></a>
+                        <a href="/"></a> 
+                    </li>
+                    <li>
+                        <a class="page-scroll" href="#dates">About</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="#speakers">Speakers</a>
                     </li>
-                    <li>
-                        <a class="page-scroll" href="#about">About</a>
+					<li>
+                        <a class="page-scroll" href="#sponsors">Sponsors</a>
+                    </li>
+					<li>
+                        <a class="page-scroll" href="#scholarships">Scholarships</a>
+                    </li>
+					<li>
+                        <a class="page-scroll" href="#locations">Locations</a>
+                    </li>
+					<li>
+                        <a class="page-scroll" href="#about">More Info</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="#team">Team</a>
+                    </li>
+					<li>
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
 		    <li>

--- a/_includes/2023_data/header-home.html
+++ b/_includes/2023_data/header-home.html
@@ -41,9 +41,6 @@ function growShrinkLogo() {
                         <a href="/"></a> 
                     </li>
                     <li>
-                        <a class="page-scroll" href="#dates">About</a>
-                    </li>
-                    <li>
                         <a class="page-scroll" href="#speakers">Speakers</a>
                     </li>
 					<li>
@@ -56,7 +53,7 @@ function growShrinkLogo() {
                         <a class="page-scroll" href="#locations">Locations</a>
                     </li>
 					<li>
-                        <a class="page-scroll" href="#about">More Info</a>
+                        <a class="page-scroll" href="#about">More info</a>
                     </li>
                     <li>
                         <a class="page-scroll" href="#team">Team</a>

--- a/_includes/2023_data/intro.html
+++ b/_includes/2023_data/intro.html
@@ -3,7 +3,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Welcome!</h2>
+					<h2 class="section-heading">Welcome!</h2>
                 </div>
             </div>
             <div class="row container">
@@ -12,14 +12,11 @@
 		<br>
 		This year marks the 32. TaCoS and our team at Heinrich-Heine University in Düsseldorf is proud to host the event this summer.
 		</p>
-        <div>
 		More information follows as we progress. Sign up to our newsletter to recieve updates on the conference. 
 		</div>
 		</p>
 		<center><a href="https://docs.google.com/forms/d/e/1FAIpQLSfuQaKA4w67P2gnkGZPbSFiQEJyqMo2YlbWww-Wh5rXL-8Xdg/viewform" class="page-scroll btn btn-xl">Sign up for the newsletter</a></center>
                 <p><a href="https://linguistik.computer/">Previous TaCoS conferences</a> 
-                </p>
-		</center>
-            </div>
+                </p>            
         </div>
     </section>

--- a/_includes/2023_data/scholarships.html
+++ b/_includes/2023_data/scholarships.html
@@ -1,5 +1,5 @@
 <!-- Services Section -->
-    <section id="intro">
+    <section id="scholarships">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">

--- a/_includes/2023_data/sponsors.html
+++ b/_includes/2023_data/sponsors.html
@@ -1,5 +1,5 @@
 <!-- Clients Aside -->
-    
+<section id="sponsors">   
     <aside class="clients" class="bg-light-gray">
         <div class="container">
             <div class="row">

--- a/_includes/2023_data/team_members.html
+++ b/_includes/2023_data/team_members.html
@@ -1,5 +1,5 @@
 <!-- Portfolio Grid Section -->
-    <section id="speakers" class="bg-light-gray">
+    <section id="team" class="bg-light-gray">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">

--- a/_includes/2023_data/team_members.html
+++ b/_includes/2023_data/team_members.html
@@ -1,9 +1,9 @@
 <!-- Portfolio Grid Section -->
-    <section id="team" class="bg-light-gray">
+    <section id="speakers" class="bg-light-gray">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2 class="section-heading">Meet the team!</h2>
+                    <h2 id="team" class="section-heading">Meet the team!</h2>
                     <h3 class="section-subheading text-muted"></h3>
                 </div>
             </div>

--- a/_layouts/2023_home.html
+++ b/_layouts/2023_home.html
@@ -25,16 +25,16 @@
         </div>
     </header>
 
-    {% include 2023_data/intro.html %}
+    {% include 2023_data/dates.html %}
 	{% include 2023_data/speakers.html %}
-	{% include 2023_data/speakers_info.html %}
+		{% include 2023_data/speakers_info.html %}
 	{% include 2023_data/sponsors.html %}
-	{% include 2023_data/locations.html %}
-	{% include 2023_data/locations_info.html %}
-    {% include 2023_data/about.html %}
 	{% include 2023_data/scholarships.html %}
+	{% include 2023_data/locations.html %}
+		{% include 2023_data/locations_info.html %}
+	{% include 2023_data/about.html %}
 	{% include 2023_data/team_members.html %}
-	{% include 2023_data/team_members_info.html %}
+		{% include 2023_data/team_members_info.html %}
     {% include 2023_data/contact.html %}
     {% include 2023_data/footer.html %}
     {% include 2023_data/js.html %}


### PR DESCRIPTION
## SERVE LOCALLY BEFORE APPROVING.

This is a lot of changes, this is not good practice but sue me. 

## The menu bar now includes all subsections

FYI I move the scholarship section below the sponsors since I felt that they kind of belong to eachother (?). Feel free to reverse that tho. 
One could make an argument for taking scholarships out of the menu (or abbreviating it). The menu is a bit crowded right now and therefore it sinks down when you are at the top of the page.  

## Added an important dates section. 

If anybody can make a box around that section (imo not including the heading) I think that would be great. I ddin manage to make one that includes the `call for papers` and `registration` since I made those with headings and the box that I was trying to use did not permit headings in the box. 

### Added an 'm' on accommodations. 


