### PR TITLE
moves intro columns next to each other and adds invisible buttons

### DIFF
--- a/_includes/2023_css/agency.css
+++ b/_includes/2023_css/agency.css
@@ -53,6 +53,10 @@ p {
 	font-size: 110%;
 }
 
+p.block {
+	text-align: justify
+}
+
 p.large {
     font-size: 120%;
 }
@@ -178,6 +182,25 @@ fieldset[disabled] .btn-primary.active {
     text-transform: uppercase;
     font-family: {{ site.data.template.font.primary }};
 }
+
+.biggertext {
+	font-size: 1.3em;
+}
+
+/*
+.container {
+      display:flex;
+	  flex-direction: row;
+	  flex-wrap: nowrap;
+	  justify-content: center;
+	  align-items: flex-start;
+	  align-content: flex-start;
+    }
+	
+.item {
+  flex-grow: 5; /* default 0 */
+}
+*/
 
 .btn-sm:hover,
 .btn-sm:focus,
@@ -825,6 +848,21 @@ ul.social-buttons li a {
     -webkit-transition: all .3s;
     -moz-transition: all .3s;
     transition: all .3s;
+}
+/*
+ul.mylist {
+    text-align: left;
+    list-style-position: inside;
+}*/
+
+ul {
+    text-align: center;
+    list-style-position: inside;
+}
+li span {
+	position: relative;
+	left: 0px;
+	right: 100px;
 }
 
 ul.social-buttons li a:hover,

--- a/_includes/2023_data/dates.html
+++ b/_includes/2023_data/dates.html
@@ -4,20 +4,26 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
 			<h2 class="section-heading">Important Dates</h2>
-				<h3 class="section-heading">Call for Papers</h3>
-					<!-- <b>Opens March 10th</b> and <b>closes April 10th</b> -->
-					- Opens March 10th
-					<br>
-					- Closes April 10th
-					<br>
-					Notice of acceptance will be sent by <b>May 22th</b>.
-					<br> 
-				<h3 class="section-heading">Registration</h3>
-				- Opens very soon
-				<br> 
-				- Closes June 1st. 
+				<h1 class="section-heading">Call for Papers</h3>
+					<div class="biggertext">
+						- Opens March 10th
+						<br>
+						- Closes April 10th
+						<br>
+						Notice of acceptance will be sent by <b>May 22th</b>.
+						<br> 
+						<a href="INSERT CFP LINK HERE" class="btn-sm">Sign up</a>
+					</div>
 				<br>
-				<hr style="height:30pt; visibility:hidden;" />
+				<h1 class="section-heading">Registration</h3>
+				<div class="biggertext">
+					- Opens very soon
+					<br> 
+					- Closes June 1st. 
+					<br>
+					<a href="INSERT REGISTRATION LINK HERE" class="page-scroll btn btn-sm">Register </a>
+				</div>
+				<hr style="height:20pt; visibility:hidden;" />
 				<h2 class="section-heading">What is the TaCoS?</h2>
 					<center>
 					<p> The Tagung der Computerlinguistik-Studierenden (TaCoS) was first organized in 1992 and takes place once every year. It offers students of computational linguistics and adjacent fields a chance to exchange views during talks and workshops. The conference is hosted by teams of student volunteers at their university. Participants traditionally receive accommodation and breakfast in exchange for a small fee. At the center of the conference stand talks, workshops, and poster sessions; each given by students for students. Established academics from the host university are invited as keynote speakers as well. In addition, there is a social program for everyone to connect and network.

--- a/_includes/2023_data/newIntro.html
+++ b/_includes/2023_data/newIntro.html
@@ -1,0 +1,54 @@
+<!-- Portfolio Grid Section -->
+    <section id="intro" class="bg-light-gray">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h3 class="section-subheading text-muted"></h3>
+                </div>
+            </div>
+            <div class="row">
+				<div class="col-md-6 speakers-item">
+				<center>
+				<h2 class="section-heading">What is the TaCoS?</h2>
+					<p class="block"> The Tagung der Computerlinguistik-Studierenden (TaCoS) was first organized in 1992 and takes place once every year. It offers students of computational linguistics and adjacent fields a chance to exchange views during talks and workshops. The conference is hosted by teams of student volunteers at their university. Participants traditionally receive accommodation and breakfast in exchange for a small fee. At the center of the conference stand talks, workshops, and poster sessions; each given by students for students. Established academics from the host university are invited as keynote speakers as well. In addition, there is a social program for everyone to connect and network.
+					<br>
+					This year marks the 32. TaCoS and our team at Heinrich-Heine University in Düsseldorf is proud to host the event this summer.
+					</p>
+				<a href="https://docs.google.com/forms/d/e/1FAIpQLSfuQaKA4w67P2gnkGZPbSFiQEJyqMo2YlbWww-Wh5rXL-8Xdg/viewform" class="page-scroll btn btn-sm">Sign up for the newsletter</a>
+				<p><a href="https://linguistik.computer/">Previous TaCoS conferences</a></p> 
+				<ul class="list-inline social-buttons">
+                    {% for network in site.social %}
+                        <li><a href="{{ network.url }}"><i class="fa fa-{{ network.title }}"></i></a></li>
+                    {% endfor %}
+                </ul>
+				</center>				
+				</div>
+				<div class="col-md-6 speakers-item">
+					<center>
+					<h2 class="section-heading">Important Dates</h2>
+					<h1 class="section-heading">Call for Papers</h3>
+						<div class="biggertext">
+							<center>
+							<ul class="mylist">
+								<li>Opens March 10th</li>
+								<li>Closes April 10th</li>
+							</ul>
+							</center>
+							Notice of acceptance will be sent by <b>May 22th</b>.
+							<br> 
+							<!--<a href="INSERT CFP LINK HERE" class="btn-sm">Sign up</a>-->
+						</div>
+					<br>
+					<h1 class="section-heading">Registration</h3>
+					<div class="biggertext">
+						<ul>
+							<li>Opens February 27th</li>
+							<li>Closes June 1st</li>
+						</ul>
+						<!--<a href="INSERT REGISTRATION LINK HERE" class="page-scroll btn btn-sm">Register </a>-->
+					</center>					
+					</div>
+				</div>
+            </div>
+        </div>
+    </section>

--- a/_includes/2023_data/newIntro.html
+++ b/_includes/2023_data/newIntro.html
@@ -26,6 +26,15 @@
 				<div class="col-md-6 speakers-item">
 					<center>
 					<h2 class="section-heading">Important Dates</h2>
+					<h1 class="section-heading">Registration</h3>
+					<div class="biggertext">
+						<ul>
+							<li>Opens February 27th</li>
+							<li>Closes June 1st</li>
+						</ul>
+						<a href="INSERT REGISTRATION LINK HERE" class="page-scroll btn btn-sm">Register </a>
+					</div>
+					<br>
 					<h1 class="section-heading">Call for Papers</h3>
 						<div class="biggertext">
 							<center>
@@ -35,19 +44,10 @@
 							</ul>
 							</center>
 							Notice of acceptance will be sent by <b>May 22th</b>.
-							<br> 
-							<!--<a href="INSERT CFP LINK HERE" class="btn-sm">Sign up</a>-->
+							<br>						
+							<a href="INSERT CFP LINK HERE" class="btn-sm">Submit your abstract</a>
 						</div>
-					<br>
-					<h1 class="section-heading">Registration</h3>
-					<div class="biggertext">
-						<ul>
-							<li>Opens February 27th</li>
-							<li>Closes June 1st</li>
-						</ul>
-						<!--<a href="INSERT REGISTRATION LINK HERE" class="page-scroll btn btn-sm">Register </a>-->
 					</center>					
-					</div>
 				</div>
             </div>
         </div>

--- a/_includes/2023_data/scholarships.html
+++ b/_includes/2023_data/scholarships.html
@@ -11,9 +11,9 @@
 		<p> We currently offer two diversity scholarships for students who would like to give a talk at the TaCos! These scholarships will cover the conference fee and
 		some traveling expenses. To apply for a scholarship use the contact form below or send us an email: <a href= "mailto:tacos2023@linguistik.computer">tacos2023@linguistic.computer</a>
 			
-		<div class="col-md-2 col-sm-4 col-md-offset-5 col-sm-offset-4">
-                    <a href="https://societaslinguistica.eu/" class="portfolio-link" data-toggle="modal">
-                        <img src="../css/2023_style/img/logos/SLE.png" class="img-responsive img-centered" alt="Visit SLE to see what they do!">
+		<div class="col-md-6 col-sm-4 col-md-offset-3 col-sm-offset-4">
+                    <a href="https://dig-hum.de/ueber-dhd" class="portfolio-link" data-toggle="modal">
+                        <img src="../css/2023_style/img/logos/DHD.png" class="img-responsive img-centered" alt="Visit Digital Humanitites to see what they do!">
                     </a>
                 </div>
 		</div>

--- a/_layouts/2023_home.html
+++ b/_layouts/2023_home.html
@@ -24,8 +24,8 @@
             </div>
         </div>
     </header>
-
-    {% include 2023_data/dates.html %}
+	
+	{% include 2023_data/newIntro.html %}
 	{% include 2023_data/speakers.html %}
 		{% include 2023_data/speakers_info.html %}
 	{% include 2023_data/sponsors.html %}


### PR DESCRIPTION
## Swaps DHD logo with SLE logo in scholarships
We had the wrong sponsor picture there

## Invisible buttons
There is a button underneath 'Call for papers' and 'Registration' that can be uncommented and linked once we have the easy chair pages. I have checked that it works if you put a link in there. 

## Intro section
Important dates and the 'what is the tacos' text are now next to eachother to make it look nicer. 

## Twitter logo. 
Twitter logo is now also underneath the 'what is tacos' text. I think this is more prominent than then footer (which is still there nontheless).  We should add instagram and mastodon  to the socials (i think in _config?) in order to also display it here. I didnt just add it inline but used the same loop as for the footer so we dont have to change it manually everytime. 

### Comment away ...