### PR TITLE
fixed paragraph breaks

### DIFF
--- a/_2023_pages/cfp.html
+++ b/_2023_pages/cfp.html
@@ -11,7 +11,7 @@ published: true
 	
    <div class="event black-frame">
       <h1>{{ page.title }}</h1>
-		<div class="container">
+
 			<h2 class="section-heading">Important Dates</h2> 
 				<hr/>
 					<div class="biggertext">
@@ -47,5 +47,5 @@ published: true
 				<div class="biggertext">
 					If you have any further questions regarding the call for papers you can send us a mail at <a href="mailto:tacos2023@linguistik.computer?subject=Registration%2032.TaCoS">tacos2023@linguistik.computer</a>.
 				</div>
-		</div>
+
 	</div>

--- a/_2023_pages/register.html
+++ b/_2023_pages/register.html
@@ -11,7 +11,7 @@ published: true
 	
    <div class="event black-frame">
       <h1>{{ page.title }}</h1>
-		<div class="container">
+
 				<h2 class="section-heading">Important Dates</h2> 
 				<hr/>
 					<div class="biggertext">
@@ -59,5 +59,5 @@ published: true
 					<div class="biggertext">
 						If you have any further questions regarding the registration you can send us a mail at <a href="mailto:tacos2023@linguistik.computer?subject=Registration%2032.TaCoS">tacos2023@linguistik.computer</a>.
 					</div>
-		</div>
+
 	</div>

--- a/_2023_pages/register.html
+++ b/_2023_pages/register.html
@@ -20,7 +20,14 @@ published: true
 								<li>Closes June 1st</li>
 						</ul>
 					&nbsp;&nbsp;
-					<p>Sign up here: <a href="https://anmeldung.stuts.de/tacos23_de" class="btn-sm">German Registration</a> <a href="https://anmeldung.stuts.de/tacos23_en" class="btn-sm">English Registration</a>	
+					<p>
+					Sign up here:
+					</p>					
+					<center>
+					<a href="https://anmeldung.stuts.de/tacos23_de" class="btn-sm">German Registration</a>
+
+					<a href="https://anmeldung.stuts.de/tacos23_en" class="btn-sm">English Registration</a>	
+					</center>
 					</div>
 					&nbsp;&nbsp;
 				<h2 class="section-heading">Conference Fee</h2>


### PR DESCRIPTION
On some screens (mine) the registration and the cfp pages were not shown correctly and the right side of the text would be obscured, I deleted the <div> that caused the pages to do that